### PR TITLE
Use local function/variable binding for performance

### DIFF
--- a/src/resty-redis-rate.lua
+++ b/src/resty-redis-rate.lua
@@ -1,11 +1,15 @@
 local redis_rate = {}
 
 local key_prefix = "ngx_rate_measuring"
+local math_floor = math.floor
+local ngx_now = ngx.now
+local ngx_null = ngx.null
+local tonumber = tonumber
 
 redis_rate.measure = function(redis_client, key)
-  local current_time = math.floor(ngx.now())
+  local current_time = math_floor(ngx_now())
   local current_second = current_time % 60
-  local current_minute = math.floor(current_time / 60) % 60
+  local current_minute = math_floor(current_time / 60) % 60
   local past_minute = (current_minute + 59) % 60
   local current_key = key_prefix .. "_{" .. key .. "}_" .. current_minute
   local past_key = key_prefix .. "_{" .. key .. "}_" .. past_minute
@@ -22,7 +26,7 @@ redis_rate.measure = function(redis_client, key)
   end
 
   local first_resp = resp[1]
-  if first_resp == ngx.null then
+  if first_resp == ngx_null then
     first_resp  = "0"
   end
   local past_counter = tonumber(first_resp)


### PR DESCRIPTION
While reading the [lua performance tips](https://www.lua.org/gems/sample.pdf) and some of the most [fast/used resty libs](https://github.com/thibaultcha/lua-cassandra/blob/master/lib/resty/cassandra/cluster.lua#L11), I noticed a used pattern where you localize all the global var/functions.

It's easy to see this, given two lua programs one using local binding to the `tonumber` function and the other using the global binding:
![image](https://user-images.githubusercontent.com/55913/60826404-2204b680-a184-11e9-825b-8251bca8d52f.png)
If you ran the luajit to see its bytecode you're going to see that the global one calls `GGET` opcode for each and every calling to `tonumber` and this opcode is expensive.
![image](https://user-images.githubusercontent.com/55913/60826561-7ad44f00-a184-11e9-967d-436a7bfdac33.png)

